### PR TITLE
Fix - webview is shown after cancellation from the app.

### DIFF
--- a/TwitterKit/TwitterKit/Social/Identity/TWTRLoginURLParser.m
+++ b/TwitterKit/TwitterKit/Social/Identity/TWTRLoginURLParser.m
@@ -69,7 +69,7 @@
 - (BOOL)isMobileSSOCancelURL:(NSURL *)url
 {
     BOOL properScheme = [self isTwitterKitRedirectURL:url];
-    BOOL cancelState = (url.host == nil) && properScheme;
+    BOOL cancelState = (url.host == nil);
 
     BOOL isCancelURL = properScheme && cancelState;
 

--- a/TwitterKit/TwitterKit/Social/Identity/TWTRMobileSSO.m
+++ b/TwitterKit/TwitterKit/Social/Identity/TWTRMobileSSO.m
@@ -78,10 +78,6 @@
 {
     if (url == nil) return NO;
     return [self.loginURLParser isTwitterKitRedirectURL:url];
-
-//    return [url.host containsString:@"secret="] &&
-//    [url.host containsString:@"secret="] &&
-//    [url.host containsString:@"username="] ;
 }
 
 - (BOOL)isWebWithURL:(NSURL *)url

--- a/TwitterKit/TwitterKit/Social/Identity/TWTRMobileSSO.m
+++ b/TwitterKit/TwitterKit/Social/Identity/TWTRMobileSSO.m
@@ -77,9 +77,11 @@
 - (BOOL)isSSOWithURL:(NSURL *)url
 {
     if (url == nil) return NO;
-    return [url.host containsString:@"secret="] &&
-    [url.host containsString:@"secret="] &&
-    [url.host containsString:@"username="] ;
+    return [self.loginURLParser isTwitterKitRedirectURL:url];
+
+//    return [url.host containsString:@"secret="] &&
+//    [url.host containsString:@"secret="] &&
+//    [url.host containsString:@"username="] ;
 }
 
 - (BOOL)isWebWithURL:(NSURL *)url


### PR DESCRIPTION
Problem

When trying to login with the app and just cancelling it, the library bypass the cancellation, treating the action as if the application doesn't exist.

Solution
Pass the cancellation "error" to the consumer.

Describe the modifications you've done.
Assume that a valid callback url (`^twitterkit-.*:\/\/`) is a proper response from the app.

Result
Now `processRedirectURL` is reached with this empty url and a `mobileSSOCancelError` is sent to the completion handler.