### PR TITLE
Fix Quote Tweet display bugs

### DIFF
--- a/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetView.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetView.m
@@ -340,9 +340,15 @@ static TWTRTweetViewTheme const TWTRTweetViewDefaultTheme = TWTRTweetViewThemeLi
     self.layer.cornerRadius = self.showBorder ? TWTRTweetViewCornerRadius : 0.0;
     self.clipsToBounds = YES;
 
+  if (self.tweet.isQuoteTweet) {
     self.attachmentContainer.layer.borderColor = borderColor.CGColor;
     self.attachmentContainer.layer.borderWidth = (2 * TWTRTweetViewBorderWidth);
     self.attachmentContainer.layer.cornerRadius = TWTRTweetViewCornerRadius;
+  } else {
+    self.attachmentContainer.layer.borderColor = UIColor.clearColor.CGColor;
+    self.attachmentContainer.layer.borderWidth = 0;
+    self.attachmentContainer.layer.cornerRadius = 0;
+  }
 }
 
 - (void)setShowActionButtons:(BOOL)showActionButtons

--- a/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetView.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetView.m
@@ -453,9 +453,8 @@ static TWTRTweetViewTheme const TWTRTweetViewDefaultTheme = TWTRTweetViewThemeLi
         [subview removeFromSuperview];
     }
 
-    // Currently only show a quote tweet as an attachment
-    // If content view already has media, does not show a quote tweet attachment
-    if (tweet.isQuoteTweet && !tweet.hasMedia) {
+    // FIX(@benward): Twitter now allows Quote Tweets and photos together
+    if (tweet.isQuoteTweet) {
         id<TWTRTweetContentViewLayout> layout = [TWTRTweetContentViewLayoutFactory quoteTweetViewLayoutWithMetrics:self.metrics];
         TWTRTweetContentView *contentView = [[TWTRTweetContentView alloc] initWithLayout:layout];
         [self.attachmentContainer addSubview:contentView];

--- a/build.sh
+++ b/build.sh
@@ -23,9 +23,27 @@ xcodebuild \
 ## Merge into one TwitterKit.framework with x86_64, armv7, arm64
 rm -rf iOS
 mkdir -p iOS
+
+# Combine simulator and iphone frameworks
 cp -r TwitterKit/iphoneos/TwitterKit.framework/ iOS/TwitterKit.framework
-lipo -create -output iOS/TwitterKit.framework/TwitterKit TwitterKit/iphoneos/TwitterKit.framework/TwitterKit TwitterKit/iphonesimulator/TwitterKit.framework/TwitterKit
+
+lipo -create -output iOS/TwitterKit.framework/TwitterKit \
+  TwitterKit/iphoneos/TwitterKit.framework/TwitterKit \
+  TwitterKit/iphonesimulator/TwitterKit.framework/TwitterKit
+
 lipo -archs iOS/TwitterKit.framework/TwitterKit
+
+# Copy bytecode symbol maps (iOS only -- not created for simulator)
+cp -av TwitterKit/iphoneos/*.bcsymbolmap iOS/
+
+# Combine dSYMs
+cp -r TwitterKit/iphoneos/TwitterKit.framework.dSYM iOS/
+
+lipo -create -output iOS/TwitterKit.framework.dSYM/Contents/Resources/DWARF/TwitterKit \
+  TwitterKit/iphoneos/TwitterKit.framework.dSYM/Contents/Resources/DWARF/TwitterKit \
+  TwitterKit/iphonesimulator/TwitterKit.framework.dSYM/Contents/Resources/DWARF/TwitterKit
+
+lipo -archs iOS/TwitterKit.framework.dSYM/Contents/Resources/DWARF/TwitterKit
 
 ## Zip them into TwitterKit.zip
 rm TwitterKit.zip


### PR DESCRIPTION
Problem

1. Twitter have updated their display guidelines to allow displaying Tweet media and Quote tweets at the same time.
2. Twitter Kit has a bug where the border outline for the Quote Tweet can still be hairline visible when there is no Quote Tweet.

Solution

* Remove restriction on rendering Quote when media is present.
* Explicitly render clear borders on attachment region when Quote is missing.

Result

* No visual glitches.
* Quotes and media can be rendered.

Not addressed

* Delegate handling for media handling assumes a single Tweet. There might be more work to do to enable interaction with quoted video + a reaction GIF, for example.