### PR TITLE
add support for different callback scheme

### DIFF
--- a/TwitterCore/TwitterCore/Networking/TWTRAuthConfig.h
+++ b/TwitterCore/TwitterCore/Networking/TWTRAuthConfig.h
@@ -32,6 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
  *  The consumer secret of the Twitter application.
  */
 @property (nonatomic, copy, readonly) NSString *consumerSecret;
+/**
+ *  The callback scheme of the Twitter application.
+ */
+@property (nonatomic, copy, readonly) NSString *callback;
 
 /**
  *  Returns an `TWTRAuthConfig` object initialized by copying the values from the consumer key and consumer secret.
@@ -40,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param consumerSecret The consumer secret.
  */
 - (instancetype)initWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret;
+
+- (instancetype)initWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret callback:(nullable NSString * )callback;
 
 /**
  *  Unavailable. Use `initWithConsumerKey:consumerSecret:` instead.

--- a/TwitterCore/TwitterCore/Networking/TWTRAuthConfig.m
+++ b/TwitterCore/TwitterCore/Networking/TWTRAuthConfig.m
@@ -30,9 +30,25 @@
 {
     NSParameterAssert(consumerKey);
     NSParameterAssert(consumerSecret);
+    self = [self initWithConsumerKey:consumerKey
+                      consumerSecret:consumerSecret
+                            callback:nil];
+    return self;
+}
+
+- (instancetype)initWithConsumerKey:(NSString *)consumerKey
+                     consumerSecret:(NSString *)consumerSecret
+                           callback:(NSString *)callback
+{
+    
+    NSParameterAssert(consumerKey);
+    NSParameterAssert(consumerSecret);
     if ((self = [super init])) {
         _consumerKey = [consumerKey copy];
         _consumerSecret = [consumerSecret copy];
+        if (callback){
+            _callback = [callback copy];
+        }
     }
     return self;
 }

--- a/TwitterKit/TwitterKit/Social/Identity/TWTRLoginURLParser.m
+++ b/TwitterKit/TwitterKit/Social/Identity/TWTRLoginURLParser.m
@@ -36,7 +36,12 @@
 - (instancetype)initWithAuthConfig:(TWTRAuthConfig *)config
 {
     if (self = [super init]) {
-        self.twitterKitURLScheme = [NSString stringWithFormat:@"twitterkit-%@", config.consumerKey];
+        if (config.callback){
+            self.twitterKitURLScheme = config.callback;
+        }
+        else {
+            self.twitterKitURLScheme = [NSString stringWithFormat:@"twitterkit-%@", config.consumerKey];
+        }
         self.twitterAuthURL = [NSString stringWithFormat:@"twitterauth://authorize?consumer_key=%@&consumer_secret=%@&oauth_callback=%@", config.consumerKey, config.consumerSecret, self.twitterKitURLScheme];
     }
     return self;

--- a/TwitterKit/TwitterKit/TWTRTwitter.h
+++ b/TwitterKit/TwitterKit/TWTRTwitter.h
@@ -67,6 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret accessGroup:(nullable NSString *)accessGroup;
 
+- (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret accessGroup:(nullable NSString *)accessGroup callback:(nullable NSString *)callback;
+
 /**
  *  The current version of this kit.
  */

--- a/TwitterKit/TwitterKit/TWTRTwitter.m
+++ b/TwitterKit/TwitterKit/TWTRTwitter.m
@@ -133,10 +133,13 @@ static TWTRTwitter *sharedTwitter;
 
 - (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret
 {
-    [self startWithConsumerKey:consumerKey consumerSecret:consumerSecret accessGroup:nil];
+    [self startWithConsumerKey:consumerKey consumerSecret:consumerSecret accessGroup:nil callback:nil];
 }
-
 - (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret accessGroup:(NSString *)accessGroup
+{
+    [self startWithConsumerKey:consumerKey consumerSecret:consumerSecret accessGroup:accessGroup callback:nil];
+}
+- (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret accessGroup:(NSString *)accessGroup callback:(NSString *)callback
 {
     if (self.isInitialized) {
         return;
@@ -149,7 +152,7 @@ static TWTRTwitter *sharedTwitter;
     [self ensureResourcesBundleExists];
     [self setupAPIServiceConfigs];
 
-    self->_authConfig = [[TWTRAuthConfig alloc] initWithConsumerKey:consumerKey consumerSecret:consumerSecret];
+    self->_authConfig = [[TWTRAuthConfig alloc] initWithConsumerKey:consumerKey consumerSecret:consumerSecret callback:callback];
 
     NSString *cacheDir = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject];
 

--- a/TwitterKit5.podspec
+++ b/TwitterKit5.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.social_media_url = "https://taoren.me"
   s.authors = "Tao Ren"
   s.platform = :ios, "9.0"
-  s.source = { :http => "https://github.com/hearther/twitter-kit-ios/releases/download/#{s.version}/TwitterKit.zip" }
+  s.source = { :http => "https://github.com/hearther/twitter-kit-ios/releases/download/v#{s.version}/TwitterKit.zip" }
   s.vendored_frameworks = "iOS/TwitterKit.framework"
   s.license = { :type => "Commercial", :text => "Twitter Kit: Copyright Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Twitter Kit Agreement located at https://dev.twitter.com/overview/terms/twitterkit and the Developer Agreement located at https://dev.twitter.com/overview/terms/agreement. OSS: https://github.com/twitter/twitter-kit-ios/blob/master/OS_LICENSES.md"}
   s.resources = ["iOS/TwitterKit.framework/TwitterKitResources.bundle", "iOS/TwitterKit.framework/TwitterShareExtensionUIResources.bundle"]

--- a/TwitterKit5.podspec
+++ b/TwitterKit5.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name = "TwitterKit5"
-  s.version = "5.2.0"
+  s.version = "5.2.1"
   s.summary = "Increase user engagement and app growth."
   s.homepage = "https://github.com/touren/twitter-kit-ios"
   s.documentation_url = "https://github.com/touren/twitter-kit-ios/wiki"
   s.social_media_url = "https://taoren.me"
   s.authors = "Tao Ren"
   s.platform = :ios, "9.0"
-  s.source = { :http => "https://github.com/touren/twitter-kit-ios/releases/download/v#{s.version}/TwitterKit.zip" }
+  s.source = { :http => "https://github.com/hearther/twitter-kit-ios/releases/download/v#{s.version}/TwitterKit.zip" }
   s.vendored_frameworks = "iOS/TwitterKit.framework"
   s.license = { :type => "Commercial", :text => "Twitter Kit: Copyright Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Twitter Kit Agreement located at https://dev.twitter.com/overview/terms/twitterkit and the Developer Agreement located at https://dev.twitter.com/overview/terms/agreement. OSS: https://github.com/twitter/twitter-kit-ios/blob/master/OS_LICENSES.md"}
   s.resources = ["iOS/TwitterKit.framework/TwitterKitResources.bundle", "iOS/TwitterKit.framework/TwitterShareExtensionUIResources.bundle"]

--- a/TwitterKit5.podspec
+++ b/TwitterKit5.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.social_media_url = "https://taoren.me"
   s.authors = "Tao Ren"
   s.platform = :ios, "9.0"
-  s.source = { :http => "https://github.com/hearther/twitter-kit-ios/releases/download/v#{s.version}/TwitterKit.zip" }
+  s.source = { :http => "https://github.com/hearther/twitter-kit-ios/releases/download/#{s.version}/TwitterKit.zip" }
   s.vendored_frameworks = "iOS/TwitterKit.framework"
   s.license = { :type => "Commercial", :text => "Twitter Kit: Copyright Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Twitter Kit Agreement located at https://dev.twitter.com/overview/terms/twitterkit and the Developer Agreement located at https://dev.twitter.com/overview/terms/agreement. OSS: https://github.com/twitter/twitter-kit-ios/blob/master/OS_LICENSES.md"}
   s.resources = ["iOS/TwitterKit.framework/TwitterKitResources.bundle", "iOS/TwitterKit.framework/TwitterShareExtensionUIResources.bundle"]


### PR DESCRIPTION
Problem

Twitter can support several callback scheme when you have to support several apps. But currently sdk only can use twitterkit-[consumerKey] as scheme url. And it  cause problem with apps. 

Solution

Add support to change the call back scheme.


