### PR TITLE
Increased MaxTweetLength to 280

### DIFF
--- a/TwitterKit/TwitterKit/Social/Syndication/ThirdParty/TWTRTwitterText.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/ThirdParty/TWTRTwitterText.m
@@ -240,7 +240,7 @@
 
 #pragma mark - Constants
 
-static const NSUInteger MaxTweetLength = 140;
+static const NSUInteger MaxTweetLength = 280;
 static const NSUInteger HTTPShortURLLength = 23;
 static const NSUInteger HTTPSShortURLLength = 23;
 


### PR DESCRIPTION
Updates max characters in a tweet to match the current character limit by Twitter.

Problem

Currently posting tweets through the SDK has a hardcoded limit of 140 characters.
[Twitter increased that value to 280.](https://developer.twitter.com/en/docs/basics/counting-characters)

Solution

Update the hardcoded value to 280.

Result

The SDK will allow creating tweets with up to 280 characters and increase the height of the tweet composer UI.
