### PR TITLE
Fix the type of twitterText

### DIFF
--- a/TwitterKit/TwitterKit/TwitterShareExtensionUI/Public/TWTRSETweet.h
+++ b/TwitterKit/TwitterKit/TwitterShareExtensionUI/Public/TWTRSETweet.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TWTRSETweet : NSObject <NSCopying>
 
-+ (void)setTwitterText:(id<TwitterTextProtocol>)twitterText;
++ (void)setTwitterText:(Class<TwitterTextProtocol>)twitterText;
 + (Class<TwitterTextProtocol>)twitterText;
 
 @property (nonatomic, nullable, copy) NSNumber *inReplyToTweetID;


### PR DESCRIPTION
TWTRSETweet.m and usage of setTwitterText expects a Class type rather than an object pointer. This causes compilation error on XCode13